### PR TITLE
feat: add GitHub Codespaces dev container configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,28 +4,10 @@
   "customizations": {
     "codespaces": {
       "openFiles": ["README.md"]
-    },
-    "vscode": {
-      "extensions": [
-        "ms-dotnettools.csdevkit",
-        "microsoft-IsvExpTools.powerplatform-vscode",
-        "GitHub.copilot",
-        "GitHub.copilot-chat",
-        "ms-vscode.powershell",
-        "hashicorp.terraform",
-        "redhat.vscode-yaml"
-      ]
-    }
-  },
-  "secrets": {
-    "DATAVERSE_ENV_URL": {
-      "description": "Your Dataverse / Power Platform environment URL (e.g. https://contoso.crm4.dynamics.com). Used by pac and txc CLI to connect to your environment.",
-      "documentationUrl": "https://learn.microsoft.com/power-platform/developer/cli/reference/auth#pac-auth-create"
     }
   },
   "hostRequirements": {
     "cpus": 2,
     "memory": "8gb"
-  },
-  "postCreateCommand": "echo '✅ Power Platform dev environment ready. Run `pac auth create` to connect to your environment.'"
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+  "name": "Power Platform",
+  "image": "ghcr.io/talxis/tools-agentbox/image:latest",
+  "customizations": {
+    "codespaces": {
+      "openFiles": ["README.md"]
+    },
+    "vscode": {
+      "extensions": [
+        "ms-dotnettools.csdevkit",
+        "microsoft-IsvExpTools.powerplatform-vscode",
+        "GitHub.copilot",
+        "GitHub.copilot-chat",
+        "ms-vscode.powershell",
+        "hashicorp.terraform",
+        "redhat.vscode-yaml"
+      ]
+    }
+  },
+  "secrets": {
+    "DATAVERSE_ENV_URL": {
+      "description": "Your Dataverse / Power Platform environment URL (e.g. https://contoso.crm4.dynamics.com). Used by pac and txc CLI to connect to your environment.",
+      "documentationUrl": "https://learn.microsoft.com/power-platform/developer/cli/reference/auth#pac-auth-create"
+    }
+  },
+  "hostRequirements": {
+    "cpus": 2,
+    "memory": "8gb"
+  },
+  "postCreateCommand": "echo '✅ Power Platform dev environment ready. Run `pac auth create` to connect to your environment.'"
+}

--- a/README.md
+++ b/README.md
@@ -8,19 +8,9 @@ Each folder in this repository represents a separate topic or scenario that demo
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TALXIS/docs-patterns-practices?quickstart=1)
 
-This repository is pre-configured for GitHub Codespaces with all Power Platform tools ready to go — no local installation needed.
+Click the badge to open a pre-configured development environment with all Power Platform tools ready to go — no local installation needed.
 
-**Included tools:** .NET 10 SDK · Node.js 22 · Azure CLI · PowerShell · Terraform · GitHub CLI · GitHub Copilot CLI · Power Platform CLI (`pac`) · TALXIS DevKit CLI (`txc`) · Azure Functions Core Tools
-
-### Workshop participants: start here
-
-> ⚠️ **You must fork this repository before starting.** Parts of this lab involve creating and running GitHub Actions workflows, which require write access to a repository. You cannot push workflows to the upstream repo — your fork is your workspace.
-
-1. **Fork this repository** — click **Fork** in the top-right corner of this page
-2. **Open your fork in Codespaces** — on your fork, click the green **Code** button → **Codespaces** tab → **Create codespace on master**
-3. Once the environment is ready, run `pac auth create` in the terminal to connect to your Power Platform environment
-
-> 💡 The badge above is a quick reference link for maintainers. Always start from **your fork**.
+> ⚠️ **If you plan to commit changes or run GitHub Actions pipelines** (required for most labs), you need your own fork. GitHub will create one automatically the first time you push — just follow the prompt in the Codespaces terminal. Alternatively, fork this repository before you start and open the Codespace from your fork.
 
 ## Demos
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ This repository is pre-configured for GitHub Codespaces with all Power Platform 
 
 ### Workshop participants: start here
 
-1. **Fork this repository** — click **Fork** in the top-right corner of this page to create your own copy
-2. **Open your fork in Codespaces** — on your fork, click the green **Code** button → **Codespaces** tab → **Create codespace on master**
-3. When prompted, provide your `DATAVERSE_ENV_URL` secret (e.g. `https://contoso.crm4.dynamics.com`)
-4. Once the environment is ready, run `pac auth create` in the terminal to connect to your environment
+> ⚠️ **You must fork this repository before starting.** Parts of this lab involve creating and running GitHub Actions workflows, which require write access to a repository. You cannot push workflows to the upstream repo — your fork is your workspace.
 
-> 💡 The badge above opens a Codespace from the upstream reference repo. For your own fork, always use the **Code → Codespaces** button on your fork's GitHub page.
+1. **Fork this repository** — click **Fork** in the top-right corner of this page
+2. **Open your fork in Codespaces** — on your fork, click the green **Code** button → **Codespaces** tab → **Create codespace on master**
+3. Once the environment is ready, run `pac auth create` in the terminal to connect to your Power Platform environment
+
+> 💡 The badge above is a quick reference link for maintainers. Always start from **your fork**.
 
 ## Demos
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@ This repository contains examples, patterns, and demo scripts related to Power P
 
 Each folder in this repository represents a separate topic or scenario that demonstrates a specific area of Power Platform development using a code-first approach.
 
+## Getting started
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TALXIS/docs-patterns-practices?quickstart=1)
+
+This repository is pre-configured for GitHub Codespaces with all Power Platform tools ready to go — no local installation needed.
+
+**Included tools:** .NET 10 SDK · Node.js 22 · Azure CLI · PowerShell · Terraform · GitHub CLI · GitHub Copilot CLI · Power Platform CLI (`pac`) · TALXIS DevKit CLI (`txc`) · Azure Functions Core Tools
+
+### Workshop participants: start here
+
+1. **Fork this repository** — click **Fork** in the top-right corner of this page to create your own copy
+2. **Open your fork in Codespaces** — on your fork, click the green **Code** button → **Codespaces** tab → **Create codespace on master**
+3. When prompted, provide your `DATAVERSE_ENV_URL` secret (e.g. `https://contoso.crm4.dynamics.com`)
+4. Once the environment is ready, run `pac auth create` in the terminal to connect to your environment
+
+> 💡 The badge above opens a Codespace from the upstream reference repo. For your own fork, always use the **Code → Codespaces** button on your fork's GitHub page.
+
 ## Demos
 
 ### [bdd-agent-v2](./bdd-agent-v2/README.md)


### PR DESCRIPTION
## Changes

- Adds `.devcontainer/devcontainer.json` pointing to `ghcr.io/talxis/tools-agentbox/image:latest`
- Updates `README.md` with Codespaces badge and fork-based workshop instructions

## How it works for workshop participants

1. Participant forks this repo
2. On their fork, clicks **Code → Codespaces → Create codespace on master**
3. The `.devcontainer/devcontainer.json` is inherited by the fork — same tools, same config
4. Codespace starts with all tools pre-installed (pac, txc, az, dotnet, node, pwsh, terraform, gh)

## Note on the image

The `ghcr.io/talxis/tools-agentbox/image:latest` image is built from [TALXIS/tools-agentbox](https://github.com/TALXIS/tools-agentbox). Ensure that PR is merged and the `Build and Push Image` workflow has run before using this config.