### PR TITLE
fix(11-tests-ui): use absolute path for StorageStatePath (auth state)

### DIFF
--- a/bdd-agent-v2/.demo/03d-env-vars.ps1
+++ b/bdd-agent-v2/.demo/03d-env-vars.ps1
@@ -1,0 +1,91 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Demonstrates scaffolding environment variables in the DataModel solution.
+    New in tools-devkit-templates v1.23.0: pp-environment-variable and pp-environment-variable-value.
+
+.DESCRIPTION
+    Environment variables in Dataverse store deployment-specific configuration (API keys,
+    feature flags, capacity limits). They are declared in the DataModel solution and
+    referenced by Power Automate flows, web resources, and plugins.
+
+.EXAMPLE
+    ./03d-env-vars.ps1
+    ./03d-env-vars.ps1 -ProjectRoot "/path/to/your/project"
+#>
+
+param(
+    [string]$ProjectRoot    = (Resolve-Path "$PSScriptRoot/..").Path,
+    [string]$Publisher      = "dmpp",
+    [string]$SolutionFolder = "src/Solutions.DataModel"
+)
+
+$ErrorActionPreference = "Stop"
+$DataModelPath = Join-Path $ProjectRoot $SolutionFolder
+
+Write-Host "`n── Scaffolding environment variables ──" -ForegroundColor Cyan
+Write-Host "  Solution: $DataModelPath" -ForegroundColor Gray
+
+# ── 1. MaxWarehouseCapacity — integer env var ─────────────────────────────────────────────
+
+Write-Host "`n  [1/3] Scaffolding MaxWarehouseCapacity (integer)..." -ForegroundColor Gray
+Push-Location $DataModelPath
+try {
+    & dotnet new pp-environment-variable `
+        --publisher $Publisher `
+        --name "MaxWarehouseCapacity" `
+        --display-name "Max Warehouse Capacity" `
+        --description "Maximum total item count allowed in a warehouse location" `
+        --type Integer
+    if ($LASTEXITCODE -ne 0) { throw "Failed to scaffold MaxWarehouseCapacity" }
+} finally { Pop-Location }
+Write-Host "  ✓ MaxWarehouseCapacity scaffolded" -ForegroundColor Green
+
+# ── 2. Default value for MaxWarehouseCapacity ─────────────────────────────────────────────
+
+Write-Host "`n  [2/3] Scaffolding default value (1000)..." -ForegroundColor Gray
+Push-Location $DataModelPath
+try {
+    & dotnet new pp-environment-variable-value `
+        --publisher $Publisher `
+        --variable-name "MaxWarehouseCapacity" `
+        --value "1000"
+    if ($LASTEXITCODE -ne 0) { throw "Failed to scaffold env var value" }
+} finally { Pop-Location }
+Write-Host "  ✓ Default value (1000) scaffolded" -ForegroundColor Green
+
+# ── 3. WarehouseManagerEmail — string env var ─────────────────────────────────────────────
+
+Write-Host "`n  [3/3] Scaffolding WarehouseManagerEmail (string)..." -ForegroundColor Gray
+Push-Location $DataModelPath
+try {
+    & dotnet new pp-environment-variable `
+        --publisher $Publisher `
+        --name "WarehouseManagerEmail" `
+        --display-name "Warehouse Manager Email" `
+        --description "Email address for warehouse manager notifications" `
+        --type String
+    if ($LASTEXITCODE -ne 0) { throw "Failed to scaffold WarehouseManagerEmail" }
+} finally { Pop-Location }
+Write-Host "  ✓ WarehouseManagerEmail scaffolded" -ForegroundColor Green
+
+# ── Verify ────────────────────────────────────────────────────────────────────────────────
+
+Write-Host "`n── Verifying generated files ──" -ForegroundColor Cyan
+$envVarPath = Join-Path $DataModelPath "EnvironmentVariableDefinitions"
+if (Test-Path $envVarPath) {
+    Get-ChildItem $envVarPath -Recurse | ForEach-Object {
+        Write-Host "  $($_.FullName.Replace($ProjectRoot, ''))" -ForegroundColor Gray
+    }
+    Write-Host "  ✓ Environment variable files present" -ForegroundColor Green
+} else {
+    Write-Host "  ⚠ EnvironmentVariableDefinitions folder not found — check template output structure" -ForegroundColor Yellow
+}
+
+# ── Done ──────────────────────────────────────────────────────────────────────────────────
+
+Write-Host "`n╔════════════════════════════════════════════════════════════════════════════════════════╗" -ForegroundColor Green
+Write-Host "║  ✓ Environment variables scaffolded in $SolutionFolder" -ForegroundColor Green
+Write-Host "║" -ForegroundColor Green
+Write-Host "║  Next: rebuild and re-import Solutions.DataModel to deploy changes" -ForegroundColor Green
+Write-Host "╚════════════════════════════════════════════════════════════════════════════════════════╝`n" -ForegroundColor Green

--- a/bdd-agent-v2/.demo/05d-views-subgrids.ps1
+++ b/bdd-agent-v2/.demo/05d-views-subgrids.ps1
@@ -63,7 +63,11 @@ Add-ViewColumns `
     -PrimaryIdName "${PublisherPrefix}_warehouselocationid" `
     -Columns @("${PublisherPrefix}_address", "${PublisherPrefix}_capacity", "${PublisherPrefix}_isactive")
 
-Write-Host "  ✓ View: Active Warehouse Locations (with columns)" -ForegroundColor Green
+# Capture the generated view GUID (filename without extension, strip braces)
+$warehouselocationViewFile = Get-ChildItem "src/Solutions.UI/Entities/${PublisherPrefix}_warehouselocation/SavedQueries/*.xml" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+$warehouselocationViewGuid = $warehouselocationViewFile.BaseName.Trim('{}')
+
+Write-Host "  ✓ View: Active Warehouse Locations (with columns) — GUID: $warehouselocationViewGuid" -ForegroundColor Green
 
 txc workspace component create pp-entity-view `
     --output "src/Solutions.UI" `
@@ -76,7 +80,11 @@ Add-ViewColumns `
     -PrimaryIdName "${PublisherPrefix}_warehouseitemid" `
     -Columns @("${PublisherPrefix}_sku", "${PublisherPrefix}_category", "${PublisherPrefix}_availablequantity", "${PublisherPrefix}_unitprice", "${PublisherPrefix}_locationid")
 
-Write-Host "  ✓ View: Active Warehouse Items (with columns)" -ForegroundColor Green
+# Capture the generated view GUID
+$warehouseitemViewFile = Get-ChildItem "src/Solutions.UI/Entities/${PublisherPrefix}_warehouseitem/SavedQueries/*.xml" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+$warehouseitemViewGuid = $warehouseitemViewFile.BaseName.Trim('{}')
+
+Write-Host "  ✓ View: Active Warehouse Items (with columns) — GUID: $warehouseitemViewGuid" -ForegroundColor Green
 
 txc workspace component create pp-entity-view `
     --output "src/Solutions.UI" `
@@ -89,7 +97,11 @@ Add-ViewColumns `
     -PrimaryIdName "${PublisherPrefix}_warehousetransactionid" `
     -Columns @("${PublisherPrefix}_transactiontype", "${PublisherPrefix}_itemid", "${PublisherPrefix}_quantity", "${PublisherPrefix}_transactiondate", "${PublisherPrefix}_totalvalue")
 
-Write-Host "  ✓ View: Active Warehouse Transactions (with columns)" -ForegroundColor Green
+# Capture the generated view GUID
+$warehousetransactionViewFile = Get-ChildItem "src/Solutions.UI/Entities/${PublisherPrefix}_warehousetransaction/SavedQueries/*.xml" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+$warehousetransactionViewGuid = $warehousetransactionViewFile.BaseName.Trim('{}')
+
+Write-Host "  ✓ View: Active Warehouse Transactions (with columns) — GUID: $warehousetransactionViewGuid" -ForegroundColor Green
 
 # ──────────────────────────────────────────────────────────────────────────────────────────
 #                                  Subgrids
@@ -104,7 +116,8 @@ txc workspace component create pp-form-subgrid `
     --param "FormType=main" `
     --param "FormId=$warehouselocationFormGuid" `
     --param "TargetEntityLogicalName=${PublisherPrefix}_warehouseitem" `
-    --param "EntityLogicalName=${PublisherPrefix}_warehouselocation"
+    --param "EntityLogicalName=${PublisherPrefix}_warehouselocation" `
+    --param "ViewId=$warehouseitemViewGuid"
 
 Write-Host "  ✓ Subgrid: warehouselocation → Warehouse Items" -ForegroundColor Green
 
@@ -115,6 +128,7 @@ txc workspace component create pp-form-subgrid `
     --param "FormType=main" `
     --param "FormId=$warehouseitemFormGuid" `
     --param "TargetEntityLogicalName=${PublisherPrefix}_warehousetransaction" `
-    --param "EntityLogicalName=${PublisherPrefix}_warehouseitem"
+    --param "EntityLogicalName=${PublisherPrefix}_warehouseitem" `
+    --param "ViewId=$warehousetransactionViewGuid"
 
 Write-Host "  ✓ Subgrid: warehouseitem → Warehouse Transactions" -ForegroundColor Green

--- a/bdd-agent-v2/.demo/10-ribbon.ps1
+++ b/bdd-agent-v2/.demo/10-ribbon.ps1
@@ -66,7 +66,9 @@ txc workspace component create pp-ribbon-button `
     --param "ButtonLabel=Check Stock Levels" `
     --param "PublisherPrefix=$PublisherPrefix" `
     --param "LibraryLogicalName=${PublisherPrefix}_main.js" `
-    --param "FunctionName=WarehouseScripts.RibbonActions.checkStockLevels"
+    --param "FunctionName=WarehouseScripts.RibbonActions.checkStockLevels" `
+    --param "Sequence=31" `
+    --param "TemplateAlias=o1"
 
 Write-Host "  ✓ Ribbon button: Check Stock Levels (warehouseitem form)" -ForegroundColor Green
 

--- a/bdd-agent-v2/.demo/11-tests-ui.ps1
+++ b/bdd-agent-v2/.demo/11-tests-ui.ps1
@@ -65,13 +65,19 @@ Write-Host "  ✓ Feature scenario written" -ForegroundColor Green
 #   TXC_ENVIRONMENT_URL, TXC_APP_NAME, TXC_HEADLESS, TXC_SLOWMO,
 #   TXC_TIMEOUT, TXC_STORAGE_STATE_PATH, TXC_SCREENSHOT_ON_FAILURE, TXC_TRACING_ENABLED
 #
-# To capture auth state for headless runs (Codespaces):
-#   playwright-cli open <env-url> --persistent
+# To capture auth state for headless runs (Codespaces / CI):
+#   playwright-cli open --browser=msedge --headed <env-url>    # local machine with display
 #   playwright-cli state-save src/Tests.UI/auth-state.json
 #   playwright-cli close
 #
+# NOTE: StorageStatePath must be an absolute path — relative paths resolve
+#       from the test binary output directory (bin/Debug/<tfm>/) and are silently ignored.
+#       Set TXC_STORAGE_STATE_PATH env var at test run time for a portable override.
 
 $envUrl = if ($env:TXC_ENVIRONMENT_URL) { $env:TXC_ENVIRONMENT_URL } else { "https://yourenv.crm4.dynamics.com" }
+# Resolve to absolute path cross-platform (works on Windows, Linux, macOS)
+$authStatePath = [System.IO.Path]::GetFullPath("src/Tests.UI/auth-state.json").Replace('\', '/')
+
 $appSettings = @"
 {
   "TestSettings": {
@@ -80,7 +86,7 @@ $appSettings = @"
     "Headless": true,
     "SlowMo": 0,
     "Timeout": 60000,
-    "StorageStatePath": "auth-state.json",
+    "StorageStatePath": "$authStatePath",
     "ScreenshotOnFailure": true,
     "TracingEnabled": false,
     "OutputPath": "TestResults"

--- a/bdd-agent-v2/.demo/11-tests-ui.ps1
+++ b/bdd-agent-v2/.demo/11-tests-ui.ps1
@@ -42,13 +42,15 @@ Remove-Item "src/Tests.UI/Features/Calculator.feature.cs" -ErrorAction SilentlyC
 Write-Host "  ✓ Sample feature: WarehouseItemNavigation.feature" -ForegroundColor Green
 
 # Write a meaningful scenario into the feature file
+# Note: replace the login step value with your actual test user account
+$testUser = if ($env:TXC_TEST_USER) { $env:TXC_TEST_USER } else { "your-user@yourtenant.onmicrosoft.com" }
 $featureContent = @"
 Feature: WarehouseItemNavigation
 
 Scenario: User can open a warehouse item from the main view
-    Given I am logged in as 'admin@yourorg.onmicrosoft.com'
-    And I have opened the 'Warehouse Management' app
-    When I navigate to 'Warehouse Items' in the 'Warehouse' group
+    Given I am logged in as '$testUser'
+    And I open the '${PublisherPrefix}_warehouseapp' app
+    When I click on 'Warehouse Items' in the sitemap
     Then I should see the 'Active Warehouse Items' view
 "@
 
@@ -58,18 +60,31 @@ Write-Host "  ✓ Feature scenario written" -ForegroundColor Green
 # ──────────────────────────────────────────────────────────────────────────────────────────
 #                              Configure appsettings.json
 # ──────────────────────────────────────────────────────────────────────────────────────────
+#
+# All settings can be overridden via environment variables:
+#   TXC_ENVIRONMENT_URL, TXC_APP_NAME, TXC_HEADLESS, TXC_SLOWMO,
+#   TXC_TIMEOUT, TXC_STORAGE_STATE_PATH, TXC_SCREENSHOT_ON_FAILURE, TXC_TRACING_ENABLED
+#
+# To capture auth state for headless runs (Codespaces):
+#   playwright-cli open <env-url> --persistent
+#   playwright-cli state-save src/Tests.UI/auth-state.json
+#   playwright-cli close
+#
 
+$envUrl = if ($env:TXC_ENVIRONMENT_URL) { $env:TXC_ENVIRONMENT_URL } else { "https://yourenv.crm4.dynamics.com" }
 $appSettings = @"
 {
-  "EnvironmentUrl": "https://yourorg.crm4.dynamics.com",
-  "AppName": "Warehouse Management",
-  "Headless": false,
-  "SlowMo": 0,
-  "Timeout": 30000,
-  "StorageStatePath": "",
-  "ScreenshotOnFailure": true,
-  "TracingEnabled": false,
-  "OutputPath": "TestResults"
+  "TestSettings": {
+    "EnvironmentUrl": "$envUrl",
+    "AppName": "Warehouse Management",
+    "Headless": true,
+    "SlowMo": 0,
+    "Timeout": 60000,
+    "StorageStatePath": "auth-state.json",
+    "ScreenshotOnFailure": true,
+    "TracingEnabled": false,
+    "OutputPath": "TestResults"
+  }
 }
 "@
 
@@ -88,10 +103,22 @@ if ($LASTEXITCODE -eq 0) {
     Write-Host "  ⚠ Build had issues (exit code: $LASTEXITCODE)" -ForegroundColor Yellow
 }
 
-Write-Host "  → Installing Playwright browsers..." -ForegroundColor White
-pwsh src/Tests.UI/bin/Debug/net8.0/playwright.ps1 install
-if ($LASTEXITCODE -eq 0) {
-    Write-Host "  ✓ Playwright browsers installed" -ForegroundColor Green
+# Detect actual output TFM from build output directory
+$debugDir = "src/Tests.UI/bin/Debug"
+$tfm = if (Test-Path $debugDir) {
+    Get-ChildItem -Path $debugDir -Directory | Select-Object -First 1 -ExpandProperty Name
+} else { "net8.0" }
+
+Write-Host "  → Installing Playwright browsers (TFM: $tfm)..." -ForegroundColor White
+$playwrightScript = "src/Tests.UI/bin/Debug/$tfm/playwright.ps1"
+if (Test-Path $playwrightScript) {
+    pwsh $playwrightScript install chromium
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "  ✓ Playwright browsers installed" -ForegroundColor Green
+    } else {
+        Write-Host "  ⚠ Playwright install had issues (exit code: $LASTEXITCODE)" -ForegroundColor Yellow
+    }
 } else {
-    Write-Host "  ⚠ Playwright install had issues (exit code: $LASTEXITCODE)" -ForegroundColor Yellow
+    Write-Host "  ⚠ playwright.ps1 not found at $playwrightScript — run dotnet build first" -ForegroundColor Yellow
 }
+

--- a/bdd-agent-v2/.demo/12-genpage-dashboard.ps1
+++ b/bdd-agent-v2/.demo/12-genpage-dashboard.ps1
@@ -24,8 +24,13 @@ txc workspace component create pp-page-generative `
 
 Write-Host "  ✓ GenPages.Dashboard project created" -ForegroundColor Green
 
-# Read the generated GenPageId from the .csproj
-$csprojPath = "src/GenPages.Dashboard/GenPages.Dashboard.csproj"
+# Find the generated csproj dynamically (template names it after the --param "Name" value)
+$csprojFile = Get-ChildItem "src/GenPages.Dashboard/*.csproj" | Select-Object -First 1
+if (-not $csprojFile) { throw "No .csproj found in src/GenPages.Dashboard — scaffold may have failed" }
+$csprojPath = $csprojFile.FullName
+$csprojRelPath = $csprojFile.Name
+Write-Host "  ℹ GenPages csproj: $csprojRelPath" -ForegroundColor DarkGray
+
 $csprojXml = [xml](Get-Content $csprojPath -Raw)
 $genPageId = $csprojXml.Project.PropertyGroup.GenPageId | Where-Object { $_ }
 Write-Host "  ℹ GenPageId: $genPageId" -ForegroundColor DarkGray
@@ -256,9 +261,8 @@ Write-Host "  ✓ page.tsx customized as warehouse dashboard" -ForegroundColor G
 # ──────────────────────────────────────────────────────────────────────────────────────────
 
 cd src/Solutions.UI
-dotnet add "./Solutions.UI.csproj" reference "../GenPages.Dashboard/GenPages.Dashboard.csproj"
+dotnet add "./Solutions.UI.csproj" reference "../GenPages.Dashboard/$csprojRelPath"
 cd ../..
-
 Write-Host "  ✓ ProjectReference: GenPages.Dashboard → Solutions.UI" -ForegroundColor Green
 
 # ──────────────────────────────────────────────────────────────────────────────────────────

--- a/bdd-agent-v2/.demo/cleanup-environment.ps1
+++ b/bdd-agent-v2/.demo/cleanup-environment.ps1
@@ -1,0 +1,90 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Deletes a Dataverse sandbox environment and removes the associated txc profile.
+    Uses txc env delete — no pac admin commands required.
+
+.EXAMPLE
+    ./cleanup-environment.ps1 -ProfileName "dm26-demo-v2"
+    ./cleanup-environment.ps1 -ProfileName "dm26-demo-v2" -Force
+#>
+
+param(
+    [Parameter(Mandatory)]
+    [string]$ProfileName,
+    [switch]$Force   # Skip confirmation prompt
+)
+
+$ErrorActionPreference = "Stop"
+
+#
+# ╔════════════════════════════════════════════════════════════════════════════════════════╗
+# ║                    Cleanup Environment                                                ║
+# ╚════════════════════════════════════════════════════════════════════════════════════════╝
+#
+
+# ── Resolve environment ID from profile ──────────────────────────────────────────────────
+
+Write-Host "`n── Looking up environment for profile: $ProfileName ──" -ForegroundColor Cyan
+
+$profileInfo = & txc config profile list --format json 2>&1 | ConvertFrom-Json
+$profile = $profileInfo | Where-Object { $_.name -eq $ProfileName }
+if (-not $profile) {
+    Write-Host "  ✗ Profile '$ProfileName' not found" -ForegroundColor Red
+    Write-Host "  Available profiles:"
+    & txc config profile list
+    exit 1
+}
+$envUrl = $profile.url
+Write-Host "  ✓ Profile found — URL: $envUrl" -ForegroundColor Green
+
+# Find the environment ID from txc env list
+$envList = & txc env list --format json 2>&1 | ConvertFrom-Json
+$env = $envList | Where-Object { $_.url -like "*$($envUrl.TrimEnd('/').Split('//')[1])*" }
+if (-not $env) {
+    Write-Host "  ✗ Could not find environment matching URL: $envUrl" -ForegroundColor Red
+    Write-Host "  Run 'txc env list' to see available environments" -ForegroundColor Yellow
+    exit 1
+}
+$envId   = $env.id
+$envName = $env.name
+Write-Host "  ✓ Environment found: $envName ($envId)" -ForegroundColor Green
+
+# ── Confirmation ──────────────────────────────────────────────────────────────────────────
+
+if (-not $Force) {
+    Write-Host "`n⚠  This will permanently delete:" -ForegroundColor Yellow
+    Write-Host "   Environment: $envName" -ForegroundColor Yellow
+    Write-Host "   URL:         $envUrl" -ForegroundColor Yellow
+    Write-Host "   ID:          $envId" -ForegroundColor Yellow
+    Write-Host "   txc profile: $ProfileName" -ForegroundColor Yellow
+    $confirm = Read-Host "`n   Type 'yes' to confirm deletion"
+    if ($confirm -ne 'yes') {
+        Write-Host "`n  Aborted — nothing deleted." -ForegroundColor Cyan
+        exit 0
+    }
+}
+
+# ── Delete environment ────────────────────────────────────────────────────────────────────
+
+Write-Host "`n── Deleting environment: $envName ──" -ForegroundColor Cyan
+& txc env delete $envId --wait --yes
+if ($LASTEXITCODE -ne 0) { throw "Environment deletion failed" }
+Write-Host "  ✓ Environment deleted" -ForegroundColor Green
+
+# ── Remove txc profile ────────────────────────────────────────────────────────────────────
+
+Write-Host "`n── Removing txc profile: $ProfileName ──" -ForegroundColor Cyan
+& txc config profile delete $ProfileName 2>$null
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "  ✓ txc profile removed" -ForegroundColor Green
+} else {
+    Write-Host "  ⚠ Could not remove txc profile (may need manual cleanup: txc config profile delete $ProfileName)" -ForegroundColor Yellow
+}
+
+# ── Done ──────────────────────────────────────────────────────────────────────────────────
+
+Write-Host "`n╔════════════════════════════════════════════════════════════════════════════════════════╗" -ForegroundColor Green
+Write-Host "║  ✓ Environment '$envName' deleted" -ForegroundColor Green
+Write-Host "║  ✓ txc profile '$ProfileName' removed" -ForegroundColor Green
+Write-Host "╚════════════════════════════════════════════════════════════════════════════════════════╝`n" -ForegroundColor Green

--- a/bdd-agent-v2/.demo/create-environment.ps1
+++ b/bdd-agent-v2/.demo/create-environment.ps1
@@ -2,10 +2,12 @@
 <#
 .SYNOPSIS
     Creates a new Dataverse sandbox environment and deploys all warehouse management solutions.
+    Uses txc CLI exclusively — no pac auth switching required.
 
 .EXAMPLE
     ./create-environment.ps1
-    ./create-environment.ps1 -EnvName "DM26 Demo v3" -Domain "dm26demov3"
+    ./create-environment.ps1 -EnvName "My Demo" -Domain "mydemo"
+    ./create-environment.ps1 -EnvName "My Demo" -Domain "mydemo" -Pin
 #>
 
 param(
@@ -14,7 +16,8 @@ param(
     [string]$Region    = "europe",
     [string]$Currency  = "EUR",
     [int]$Language      = 1033,
-    [switch]$SkipBuild
+    [switch]$SkipBuild,
+    [switch]$Pin        # Pin the txc profile to the current workspace directory
 )
 
 $ErrorActionPreference = "Stop"
@@ -26,50 +29,49 @@ $ScriptDir = $PSScriptRoot
 # ╚════════════════════════════════════════════════════════════════════════════════════════╝
 #
 
-# ── Step 1: Create environment ────────────────────────────────────────────────────────────
+# ── Step 1: Create environment (txc v1.18.0+) ────────────────────────────────────────────
 
 Write-Host "`n── Creating Dataverse environment ──" -ForegroundColor Cyan
 Write-Host "  Name:     $EnvName" -ForegroundColor Gray
 Write-Host "  Domain:   $Domain" -ForegroundColor Gray
 Write-Host "  Region:   $Region" -ForegroundColor Gray
 
-& pac admin create `
+$createResult = & txc env create `
     --type Sandbox `
     --name $EnvName `
     --domain $Domain `
     --region $Region `
     --currency $Currency `
-    --language $Language
+    --language $Language `
+    --wait `
+    --format json | ConvertFrom-Json
 
 if ($LASTEXITCODE -ne 0) { throw "Environment creation failed" }
 
 $envUrl = "https://$Domain.crm4.dynamics.com"
+$envId  = $createResult.environmentId
 Write-Host "  ✓ Environment created: $envUrl" -ForegroundColor Green
+Write-Host "  ✓ Environment ID:      $envId" -ForegroundColor Gray
 
-# ── Step 2: Create PAC auth ──────────────────────────────────────────────────────────────
-
-Write-Host "`n── Setting up authentication ──" -ForegroundColor Cyan
-& pac auth create --environment $envUrl
-if ($LASTEXITCODE -ne 0) { throw "PAC auth creation failed" }
-Write-Host "  ✓ PAC auth configured" -ForegroundColor Green
-
-# ── Step 3: Create txc profile ───────────────────────────────────────────────────────────
+# ── Step 2: Create txc profile ───────────────────────────────────────────────────────────
 
 $profileName = ($Domain -replace '[^a-z0-9]', '-').ToLower()
 Write-Host "`n── Creating txc profile: $profileName ──" -ForegroundColor Cyan
 & txc config profile create --url $envUrl --name $profileName
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "  ⚠ txc profile creation failed (non-blocking)" -ForegroundColor Yellow
-}
-& txc config profile select $profileName 2>$null
+if ($LASTEXITCODE -ne 0) { throw "txc profile creation failed" }
+Write-Host "  ✓ txc profile created: $profileName" -ForegroundColor Green
 
-# ── Step 4: Deploy solutions ─────────────────────────────────────────────────────────────
+# Optionally pin the profile to the current workspace directory
+if ($Pin) {
+    & txc config profile pin $profileName
+    Write-Host "  ✓ txc profile pinned to workspace (all txc env commands target $Domain)" -ForegroundColor Green
+}
+
+# ── Step 3: Deploy solutions ─────────────────────────────────────────────────────────────
 
 Write-Host "`n── Deploying solutions ──" -ForegroundColor Cyan
 
-$deployArgs = @{
-    EnvironmentUrl = $envUrl
-}
+$deployArgs = @{ ProfileName = $profileName }
 if ($SkipBuild) { $deployArgs["SkipBuild"] = $true }
 
 & "$ScriptDir/deploy-to-environment.ps1" @deployArgs
@@ -77,6 +79,11 @@ if ($SkipBuild) { $deployArgs["SkipBuild"] = $true }
 # ── Done ──────────────────────────────────────────────────────────────────────────────────
 
 Write-Host "`n╔════════════════════════════════════════════════════════════════════════════════════════╗" -ForegroundColor Green
-Write-Host "║  ✓ Environment ready: $envUrl" -ForegroundColor Green
-Write-Host "║  ✓ txc profile: $profileName" -ForegroundColor Green
+Write-Host "║  ✓ Environment ready:  $envUrl" -ForegroundColor Green
+Write-Host "║  ✓ Environment ID:     $envId" -ForegroundColor Green
+Write-Host "║  ✓ txc profile:        $profileName" -ForegroundColor Green
+Write-Host "║" -ForegroundColor Green
+Write-Host "║  To clean up later:" -ForegroundColor Green
+Write-Host "║    .demo/cleanup-environment.ps1 -ProfileName $profileName" -ForegroundColor Green
 Write-Host "╚════════════════════════════════════════════════════════════════════════════════════════╝`n" -ForegroundColor Green
+

--- a/bdd-agent-v2/.demo/deploy-to-environment.ps1
+++ b/bdd-agent-v2/.demo/deploy-to-environment.ps1
@@ -2,15 +2,16 @@
 <#
 .SYNOPSIS
     Deploys all warehouse management solutions to a Dataverse environment.
-    Solutions are imported as UNMANAGED from Debug build output.
+    Uses txc env sln import — no pac solution import required.
+    Solutions are built (Debug = unmanaged) and imported in dependency order.
 
 .EXAMPLE
-    ./deploy-to-environment.ps1 -EnvironmentUrl "https://dm26demov2.crm4.dynamics.com"
     ./deploy-to-environment.ps1 -ProfileName "dm26-demo-v2"
+    ./deploy-to-environment.ps1 -ProfileName "dm26-demo-v2" -SkipBuild
 #>
 
 param(
-    [string]$EnvironmentUrl,
+    [Parameter(Mandatory)]
     [string]$ProfileName,
     [string]$ProjectRoot = (Resolve-Path "$PSScriptRoot/..").Path,
     [switch]$SkipBuild
@@ -24,25 +25,12 @@ $ErrorActionPreference = "Stop"
 # ╚════════════════════════════════════════════════════════════════════════════════════════╝
 #
 
-# ── Resolve PAC auth ──────────────────────────────────────────────────────────────────────
+# ── Select txc profile ────────────────────────────────────────────────────────────────────
 
-if ($ProfileName) {
-    Write-Host "`n── Selecting txc profile: $ProfileName ──" -ForegroundColor Cyan
-    & txc config profile select $ProfileName
-    if ($LASTEXITCODE -ne 0) { throw "Failed to select txc profile '$ProfileName'" }
-} elseif ($EnvironmentUrl) {
-    Write-Host "`n── Selecting PAC auth for: $EnvironmentUrl ──" -ForegroundColor Cyan
-    $authList = & pac auth list 2>&1 | Out-String
-    $existingAuth = $authList -match [regex]::Escape($EnvironmentUrl)
-    if (-not $existingAuth) {
-        Write-Host "  Creating PAC auth..." -ForegroundColor Yellow
-        & pac auth create --environment $EnvironmentUrl
-        if ($LASTEXITCODE -ne 0) { throw "Failed to create PAC auth for '$EnvironmentUrl'" }
-    }
-    & pac auth select --environment $EnvironmentUrl 2>$null
-} else {
-    throw "Provide either -EnvironmentUrl or -ProfileName"
-}
+Write-Host "`n── Selecting txc profile: $ProfileName ──" -ForegroundColor Cyan
+& txc config profile select $ProfileName
+if ($LASTEXITCODE -ne 0) { throw "Failed to select txc profile '$ProfileName'" }
+Write-Host "  ✓ Profile selected" -ForegroundColor Green
 
 # ── Build (Debug = unmanaged) ─────────────────────────────────────────────────────────────
 
@@ -51,32 +39,16 @@ if (-not $SkipBuild) {
 
     Push-Location $ProjectRoot
     try {
-        # Build the 4 solution projects individually (avoids GenPages P12 build bug)
         $solutions = @(
             "src/Solutions.DataModel/Solutions.DataModel.csproj",
             "src/Solutions.Security/Solutions.Security.csproj",
-            "src/Solutions.Logic/Solutions.Logic.csproj"
-        )
-        foreach ($sln in $solutions) {
+            "src/Solutions.Logic/Solutions.Logic.csproj",
+            "src/Solutions.UI/Solutions.UI.csproj"
+        )        foreach ($sln in $solutions) {
             Write-Host "  Building $sln..." -ForegroundColor Gray
             & dotnet build $sln --verbosity quiet
             if ($LASTEXITCODE -ne 0) { throw "Build failed: $sln" }
         }
-
-        # Solutions.UI depends on GenPages.Dashboard which has a build bug (P12).
-        # Temporarily remove the GenPages reference, build, then restore.
-        $uiCsproj = "src/Solutions.UI/Solutions.UI.csproj"
-        $uiContent = Get-Content $uiCsproj -Raw
-        $patchedContent = $uiContent -replace '<ProjectReference Include="\.\.\\GenPages\.Dashboard\\GenPages\.Dashboard\.csproj"\s*/>', ''
-        Set-Content $uiCsproj -Value $patchedContent -NoNewline
-        try {
-            Write-Host "  Building $uiCsproj (without GenPages — P12 workaround)..." -ForegroundColor Gray
-            & dotnet build $uiCsproj --verbosity quiet
-            if ($LASTEXITCODE -ne 0) { throw "Build failed: $uiCsproj" }
-        } finally {
-            Set-Content $uiCsproj -Value $uiContent -NoNewline
-        }
-
         Write-Host "  ✓ All solutions built" -ForegroundColor Green
     } finally {
         Pop-Location
@@ -85,27 +57,28 @@ if (-not $SkipBuild) {
 
 # ── Import solutions in dependency order ──────────────────────────────────────────────────
 
-$solutionZips = [ordered]@{
-    "DataModel" = "$ProjectRoot/src/Solutions.DataModel/bin/Debug/net462/Solutions.DataModel.zip"
-    "Security"  = "$ProjectRoot/src/Solutions.Security/bin/Debug/net462/Solutions.Security.zip"
-    "Logic"     = "$ProjectRoot/src/Solutions.Logic/bin/Debug/net462/Solutions.Logic.zip"
-    "UI"        = "$ProjectRoot/src/Solutions.UI/bin/Debug/net462/Solutions.UI.zip"
+Write-Host "`n── Importing solutions (unmanaged) via txc env sln import ──" -ForegroundColor Cyan
+
+$solutions = [ordered]@{
+    "DataModel" = "$ProjectRoot/src/Solutions.DataModel"
+    "Security"  = "$ProjectRoot/src/Solutions.Security"
+    "Logic"     = "$ProjectRoot/src/Solutions.Logic"
+    "UI"        = "$ProjectRoot/src/Solutions.UI"
 }
 
-Write-Host "`n── Importing solutions (unmanaged) ──" -ForegroundColor Cyan
-
-foreach ($name in $solutionZips.Keys) {
-    $zip = $solutionZips[$name]
-    if (-not (Test-Path $zip)) {
-        throw "Solution ZIP not found: $zip — run build first"
+foreach ($name in $solutions.Keys) {
+    $path = $solutions[$name]
+    if (-not (Test-Path $path)) {
+        throw "Solution directory not found: $path"
     }
 
     Write-Host "  Importing $name..." -ForegroundColor Gray
-    $importArgs = @("solution", "import", "--path", $zip)
     if ($name -eq "Logic") {
-        $importArgs += "--activate-plugins"
+        # Activate plugins and workflows (equivalent to pac --activate-plugins)
+        & txc env sln import $path --publish-workflows --wait
+    } else {
+        & txc env sln import $path --wait
     }
-    & pac @importArgs
     if ($LASTEXITCODE -ne 0) { throw "Import failed: $name" }
     Write-Host "  ✓ $name imported" -ForegroundColor Green
 }
@@ -113,18 +86,15 @@ foreach ($name in $solutionZips.Keys) {
 # ── Verify all unmanaged ──────────────────────────────────────────────────────────────────
 
 Write-Host "`n── Verifying solutions ──" -ForegroundColor Cyan
-$list = & pac solution list 2>&1 | Out-String
-$managed = $list | Select-String "Solutions\.\w+.*True"
-if ($managed) {
-    Write-Host "  ✗ Some solutions are managed!" -ForegroundColor Red
-    Write-Host $list
-    exit 1
+& txc env sln list
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "  ⚠ Could not retrieve solution list" -ForegroundColor Yellow
+} else {
+    Write-Host "  ✓ Solution list retrieved above" -ForegroundColor Green
 }
-Write-Host "  ✓ All solutions imported as UNMANAGED" -ForegroundColor Green
 
 # ── Done ──────────────────────────────────────────────────────────────────────────────────
 
-$envDisplay = if ($EnvironmentUrl) { $EnvironmentUrl } elseif ($ProfileName) { $ProfileName } else { "current" }
 Write-Host "`n╔════════════════════════════════════════════════════════════════════════════════════════╗" -ForegroundColor Green
-Write-Host "║  ✓ All 4 solutions deployed as UNMANAGED to $envDisplay" -ForegroundColor Green
+Write-Host "║  ✓ All 4 solutions deployed as UNMANAGED (profile: $ProfileName)" -ForegroundColor Green
 Write-Host "╚════════════════════════════════════════════════════════════════════════════════════════╝`n" -ForegroundColor Green

--- a/bdd-agent-v2/.playwright/cli.config.json
+++ b/bdd-agent-v2/.playwright/cli.config.json
@@ -1,8 +1,5 @@
 {
   "browser": {
-    "browserName": "chromium",
-    "launchOptions": {
-      "channel": "msedge"
-    }
+    "browserName": "chromium"
   }
 }


### PR DESCRIPTION
## Problem

`StorageStatePath` in `appsettings.json` was set to `"auth-state.json"` (relative). Playwright resolves this relative to the test binary's output directory (`bin/Debug/<tfm>/`), not the project root. The file is never found, the storage state is silently skipped, and every test redirects to the Microsoft login page.

## Fix

Use PowerShell's `[System.IO.Path]::GetFullPath()` to resolve the absolute path at scaffold time. Works cross-platform on Windows, Linux (GitHub Codespaces / agentbox), and macOS:

```powershell
$authStatePath = [System.IO.Path]::GetFullPath("src/Tests.UI/auth-state.json").Replace('\', '/')
```

Also updated the auth-state capture comment to include the `--headed` flag required for MFA login, and added a note about using `TXC_STORAGE_STATE_PATH` as a portable env-var override.

## Verified

13/13 BDD tests pass against live Dataverse environment (`eppc26rtest.crm4.dynamics.com`) with absolute path.