### PR TITLE
fix(11-tests-ui): use absolute path for StorageStatePath (auth state)

### DIFF
--- a/bdd-agent-v2/.demo/11-tests-ui.ps1
+++ b/bdd-agent-v2/.demo/11-tests-ui.ps1
@@ -66,12 +66,17 @@ Write-Host "  ✓ Feature scenario written" -ForegroundColor Green
 #   TXC_TIMEOUT, TXC_STORAGE_STATE_PATH, TXC_SCREENSHOT_ON_FAILURE, TXC_TRACING_ENABLED
 #
 # To capture auth state for headless runs (Codespaces):
-#   playwright-cli open <env-url> --persistent
+#   playwright-cli open --browser=msedge --headed <env-url>    # local machine with display
 #   playwright-cli state-save src/Tests.UI/auth-state.json
 #   playwright-cli close
 #
+# NOTE: StorageStatePath must be an absolute path — relative paths resolve from the test
+#       binary output directory (bin/Debug/<tfm>/) and are silently ignored by Playwright.
+#       Set TXC_STORAGE_STATE_PATH env var at test run time for a portable override.
 
 $envUrl = if ($env:TXC_ENVIRONMENT_URL) { $env:TXC_ENVIRONMENT_URL } else { "https://yourenv.crm4.dynamics.com" }
+# Resolve to absolute path — works cross-platform (Windows, Linux/Codespaces, macOS)
+$authStatePath = [System.IO.Path]::GetFullPath("src/Tests.UI/auth-state.json").Replace('\', '/')
 $appSettings = @"
 {
   "TestSettings": {
@@ -80,7 +85,7 @@ $appSettings = @"
     "Headless": true,
     "SlowMo": 0,
     "Timeout": 60000,
-    "StorageStatePath": "auth-state.json",
+    "StorageStatePath": "$authStatePath",
     "ScreenshotOnFailure": true,
     "TracingEnabled": false,
     "OutputPath": "TestResults"


### PR DESCRIPTION
## Problem

`StorageStatePath` in `appsettings.json` was set to `"auth-state.json"` (relative). Playwright resolves this relative to the test binary's output directory (`bin/Debug/<tfm>/`), not the project root. The file is never found, auth state is silently skipped, and tests redirect to the Microsoft login page.

## Fix

```powershell
$authStatePath = [System.IO.Path]::GetFullPath("src/Tests.UI/auth-state.json").Replace('\', '/')
```

Works cross-platform: Windows, Linux (GitHub Codespaces / agentbox), macOS. Forward slashes are valid on all platforms in .NET.

Also updated the auth-state capture comment to include `--headed` for MFA login and added a note about `TXC_STORAGE_STATE_PATH` as a portable env-var override.

## Verified

13/13 BDD tests pass against live Dataverse environment (`eppc26rtest.crm4.dynamics.com`) with this fix applied.